### PR TITLE
Test code update

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -21,7 +21,7 @@ environment:
   # This requires setting `APPVEYOR_SSH_KEY` and `APPVEYOR_SSH_BLOCK`
   ACTIVATE_SSH_LOGIN: no
 
-  INSTALL_GITANNEX: git-annex=10.20221003 -m datalad/git-annex:release
+  INSTALL_GITANNEX: git-annex -m snapshot
 
   # The root for study data and the studies that we simulate. These variables
   # are available throughout ``install:´´ and in the executed scripts.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,4 +26,5 @@ from datalad_next.tests.fixtures import (
 
 from .fixtures import (
     dicom_server,
+    dataaccess_credential,
 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,6 +21,6 @@ from datalad_next.tests.fixtures import (
 )
 
 from .fixtures import (
-    dicom_server,
+    data_webserver,
     dataaccess_credential,
 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,17 +3,13 @@ from datalad.conftest import setup_package
 # fixture setup
 from datalad_next.tests.fixtures import (
     # no test can leave global config modifications behind
-    # TODO: We cannot use this right now. It requires Git >= 2.32, but the
-    # deployment target only has 2.30
-    #check_gitconfig_global,
+    check_gitconfig_global,
     # no test can leave secrets behind
     check_plaintext_keyring,
     # function-scope credential manager
     credman,
     # function-scope config manager
-    # TODO: We cannot use this right now. It requires Git >= 2.32, but the
-    # deployment target only has 2.30
-    #datalad_cfg,
+    datalad_cfg,
     # function-scope temporary keyring
     tmp_keyring,
     # function-scope, Dataset instance

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,13 +3,17 @@ from datalad.conftest import setup_package
 # fixture setup
 from datalad_next.tests.fixtures import (
     # no test can leave global config modifications behind
-    check_gitconfig_global,
+    # TODO: We cannot use this right now. It requires Git >= 2.32, but the
+    # deployment target only has 2.30
+    #check_gitconfig_global,
     # no test can leave secrets behind
     check_plaintext_keyring,
     # function-scope credential manager
     credman,
     # function-scope config manager
-    datalad_cfg,
+    # TODO: We cannot use this right now. It requires Git >= 2.32, but the
+    # deployment target only has 2.30
+    #datalad_cfg,
     # function-scope temporary keyring
     tmp_keyring,
     # function-scope, Dataset instance

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,25 @@
+from datalad.conftest import setup_package
+
+# fixture setup
+from datalad_next.tests.fixtures import (
+    # no test can leave global config modifications behind
+    check_gitconfig_global,
+    # no test can leave secrets behind
+    check_plaintext_keyring,
+    # function-scope credential manager
+    credman,
+    # function-scope config manager
+    datalad_cfg,
+    # function-scope temporary keyring
+    tmp_keyring,
+    # function-scope, Dataset instance
+    dataset,
+    #function-scope, Dataset instance with underlying repository
+    existing_dataset,
+    #function-scope, Dataset instance with underlying Git-only repository
+    existing_noannex_dataset,
+)
+
+from .fixtures import (
+    dicom_server,
+)

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -19,13 +19,19 @@ def dataaccess_credential():
     )
 
 
-@pytest.fixture(autouse=False, scope='session')
-def dicom_server(dataaccess_credential):
+@pytest.fixture(autouse=False, scope="session")
+def test_study_names():
+    studies = []
     if os.environ.get('APPVEYOR', None) == 'true':
-        yield dict(
-            base_url='http://localhost/~appveyor',
-            studies=os.environ['STUDIES'].split(),
-        )
+        studies = os.environ['STUDIES'].split()
+    yield studies
+
+
+@pytest.fixture(autouse=False, scope='session')
+def data_webserver(dataaccess_credential):
+    """Yields a URL to a webserver providing data access"""
+    if os.environ.get('APPVEYOR', None) == 'true':
+        yield 'http://localhost/~appveyor'
     else:
         study_dir = os.environ.get(local_eny_key, None)
         if not study_dir:
@@ -41,7 +47,4 @@ def dicom_server(dataaccess_credential):
                   dataaccess_credential['secret'])
         )
         with server:
-            yield dict(
-                base_url=server.url,
-                studies=[],
-            )
+            yield server.url

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 import os
-from tempfile import TemporaryDirectory
 
 import pytest
 

--- a/tests/test_datalad_workflows/test_example.py
+++ b/tests/test_datalad_workflows/test_example.py
@@ -7,7 +7,6 @@ from datalad.api import (
     download,
 )
 from datalad.support.exceptions import IncompleteResultsError
-from datalad.utils import chpwd
 
 
 def _check_results(results: list[dict]):
@@ -27,12 +26,13 @@ def test_example_authorized(
 ):
     credman.set(**dataaccess_credential)
 
-    with chpwd(tmp_path):
-        results = download(
-            f'{data_webserver}/study_1/visit_1_dicom.tar',
-            credential=dataaccess_credential['name'],
-            result_renderer='disabled')
-        _check_results(results)
+    target_file = tmp_path / 'visit_1_dicom.tar'
 
-    elements = [Path(e).parts[-1] for e in tmp_path.iterdir()]
-    assert 'visit_1_dicom.tar' in elements
+    results = download(
+        {f'{data_webserver}/study_1/visit_1_dicom.tar': target_file},
+        credential=dataaccess_credential['name'],
+        result_renderer='disabled',
+    )
+    _check_results(results)
+
+    assert target_file.exists()

--- a/tests/test_datalad_workflows/test_example.py
+++ b/tests/test_datalad_workflows/test_example.py
@@ -10,9 +10,6 @@ from datalad.api import (
 from datalad.support.exceptions import IncompleteResultsError
 from datalad.utils import chpwd
 
-# Fixture to get the configuration of the test environment
-from ..environment import dicom_server
-
 
 def _check_results(results: list[dict]):
     assert all(result['status'] == 'ok' for result in results)

--- a/tests/test_datalad_workflows/test_example.py
+++ b/tests/test_datalad_workflows/test_example.py
@@ -14,24 +14,22 @@ def _check_results(results: list[dict]):
     assert all(result['status'] == 'ok' for result in results)
 
 
-def test_example_unauthorized(dicom_server):
-    print(dicom_server)
+def test_example_unauthorized(data_webserver):
     with pytest.raises(IncompleteResultsError):
         download(
-            f'{dicom_server["base_url"]}/study_1/visit_1_dicom.tar',
+            f'{data_webserver}/study_1/visit_1_dicom.tar',
             result_renderer='disabled')
 
 
 def test_example_authorized(
-    dicom_server, tmp_path: Path, tmp_keyring,
+    data_webserver, tmp_path: Path, tmp_keyring,
     dataaccess_credential, credman,
 ):
-    print(dicom_server)
     credman.set(**dataaccess_credential)
 
     with chpwd(tmp_path):
         results = download(
-            f'{dicom_server["base_url"]}/study_1/visit_1_dicom.tar',
+            f'{data_webserver}/study_1/visit_1_dicom.tar',
             credential=dataaccess_credential['name'],
             result_renderer='disabled')
         _check_results(results)

--- a/tests/test_datalad_workflows/test_example.py
+++ b/tests/test_datalad_workflows/test_example.py
@@ -23,7 +23,7 @@ def test_example_unauthorized(dicom_server):
             result_renderer='disabled')
 
 
-def test_example_authorized(dicom_server, tmp_path: Path):
+def test_example_authorized(dicom_server, tmp_path: Path, tmp_keyring):
     print(dicom_server)
     results = credentials(
         'set',

--- a/tests/test_datalad_workflows/test_example.py
+++ b/tests/test_datalad_workflows/test_example.py
@@ -4,7 +4,6 @@ from pathlib import Path
 import pytest
 
 from datalad.api import (
-    credentials,
     download,
 )
 from datalad.support.exceptions import IncompleteResultsError
@@ -23,21 +22,17 @@ def test_example_unauthorized(dicom_server):
             result_renderer='disabled')
 
 
-def test_example_authorized(dicom_server, tmp_path: Path, tmp_keyring):
+def test_example_authorized(
+    dicom_server, tmp_path: Path, tmp_keyring,
+    dataaccess_credential, credman,
+):
     print(dicom_server)
-    results = credentials(
-        'set',
-        name='test_creds',
-        spec={
-            'type': 'user_password',
-            'user': dicom_server['user'],
-            'secret': dicom_server['secret']})
-    _check_results(results)
+    credman.set(**dataaccess_credential)
 
     with chpwd(tmp_path):
         results = download(
             f'{dicom_server["base_url"]}/study_1/visit_1_dicom.tar',
-            credential='test_creds',
+            credential=dataaccess_credential['name'],
             result_renderer='disabled')
         _check_results(results)
 

--- a/tests/test_datalad_workflows/test_example.py
+++ b/tests/test_datalad_workflows/test_example.py
@@ -7,10 +7,7 @@ from datalad.api import (
     download,
 )
 from datalad.support.exceptions import IncompleteResultsError
-
-
-def _check_results(results: list[dict]):
-    assert all(result['status'] == 'ok' for result in results)
+from datalad_next.tests.utils import assert_status
 
 
 def test_example_unauthorized(data_webserver):
@@ -32,7 +29,7 @@ def test_example_authorized(
         {f'{data_webserver}/study_1/visit_1_dicom.tar': target_file},
         credential=dataaccess_credential['name'],
         result_renderer='disabled',
+        on_failure='ignore',
     )
-    _check_results(results)
-
+    assert_status('ok', results)
     assert target_file.exists()

--- a/tests/test_datalad_workflows/test_example.py
+++ b/tests/test_datalad_workflows/test_example.py
@@ -6,7 +6,7 @@ import pytest
 from datalad.api import (
     download,
 )
-from datalad.support.exceptions import IncompleteResultsError
+from datalad_next.exceptions import IncompleteResultsError
 from datalad_next.tests.utils import assert_status
 
 


### PR DESCRIPTION
Changes

- Disentangle fixtures, move to more standard places
- Add protection against tests leaving behind persistent configuration changes, or credentials
- Use a recent git-annex, instead of an old one -- far too many bugs have been fixed, and we are in control of the deployment. There is no reason for recreating workaround that are already obsolete
- Use more standard patterns for setting credentials and checking results