### PR TITLE
Fix demo DICOM download

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -14,12 +14,18 @@ image: Ubuntu2004
 
 
 environment:
-  # Set this to `after-install` to activate the ssh login after the
+  # Set this to `post-install` to activate the ssh login after the
   # install-steps are executed.
   # Set it to 'pre-tests' to activate ssh login just before the tests are
   # executed.
   # This requires setting `APPVEYOR_SSH_KEY` and `APPVEYOR_SSH_BLOCK`
   ACTIVATE_SSH_LOGIN: no
+
+  # The following variables should be kept in sync with INM-ICF's
+  # system configuration.
+  ICF_PYTHON_VERSION: 3.9
+  ICF_GIT_VERSION: 2.30.2
+  ICF_GIT_ANNEX_VERSION: 10.20221003
 
   INSTALL_GITANNEX: git-annex -m snapshot
 
@@ -45,7 +51,7 @@ install:
   - sudo mkdir -p "$FROM_SCANNER"
   - sh:
       for s in $STUDIES; do
-        .appveyor/data_create_scanner_output $FROM_SCANNER $s 10 20;
+        sudo .appveyor/data_create_scanner_output $FROM_SCANNER $s 10 20;
       done
   # Create study directories
   - sh:
@@ -82,7 +88,7 @@ install:
   # the worker waits with the continuation of the build beyond this point until
   # the file ``~/build.lock´´ is removed.
   - sh:
-      if [ X"$ACTIVATE_SSH_LOGIN" == "Xafter-install" ]; then
+      if [ X"$ACTIVATE_SSH_LOGIN" == "Xpost-install" ]; then
         curl -sflL 'https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-ssh.sh' | bash -e -;
       fi
 
@@ -109,6 +115,9 @@ build_script:
   - "[ -f ${HOME}/dlinstaller_env.sh ] && . ${HOME}/dlinstaller_env.sh || true"
   # all remaining deps after git-annex
   - python -m pip install -r requirements-devel.txt
+
+  # Check program versions and report
+  - .appveyor/check_versions --warn-only ${ICF_PYTHON_VERSION} ${ICF_GIT_VERSION} ${ICF_GIT_ANNEX_VERSION}
 
 
 before_test:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -131,7 +131,6 @@ test_script:
   - cd __testhome__
   - which python
   - python --version
-  - env
   - sh:
       if [ X"$ACTIVATE_SSH_LOGIN" == "Xpre-tests" ]; then
         curl -sflL 'https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-ssh.sh' | bash -e -;

--- a/.appveyor/check_versions
+++ b/.appveyor/check_versions
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+set -e -u
+
+if [ "X$1" == "X--warn-only" ]; then
+    relaxed=True
+    shift
+else
+    relaxed=""
+fi
+
+python_version="$1"; shift
+git_version="$1"; shift
+git_annex_version="$1"; shift
+
+fails=0
+function check() {
+  if [ "X$2" != "X$3" ]; then
+    if [ $relaxed ]; then
+      echo -n WARNING
+    else
+      echo -n ERROR
+      fails=$(( $fails + 1 ))
+    fi
+    echo : $1: version mismatch. Got $2, expected $3
+  fi
+}
+
+check python $( { python --version || echo Python unknown; } |cut -d " " -f 2|cut -d "." -f 1-2) $python_version
+check git $( { git --version || echo git version unknown; } |cut -d " " -f 3) $git_version
+check git-annex $( { git annex version || echo git-annex version: unknown; } |head -1|cut -d " " -f 3) $git_annex_version
+
+if [ $fails -gt 0 ]; then
+  exit 1
+fi

--- a/.appveyor/data_create_scanner_output
+++ b/.appveyor/data_create_scanner_output
@@ -15,7 +15,7 @@ url_base="https://github.com/datalad/example-dicom-structural/raw/master/dicoms/
 dicom_hierarchy=${study}_7T8088/incoming/${study}/654321_7T8088/SCANS/1/DICOM
 dicom_base_name=1.3.12.2.1107.5.2.0.79109.30000021070907115904000000007-1
 target_dir="$from_scanner_dir"/"$dicom_hierarchy"
-sudo mkdir -p "$target_dir"
+mkdir -p "$target_dir"
 
 # Copy N2D_<lower>.dcm to N2D_<upper>.dcm to $from_scanner_dir
 while [ "$lower" -le "$upper" ]; do
@@ -26,12 +26,12 @@ while [ "$lower" -le "$upper" ]; do
   target_name="$target_dir"/"$dicom_name"
 
   echo copying "$url" "->" "$target_name"
-  sudo curl -s -o "$target_name" "$url"
+  curl -s -L -o "$target_name" "$url"
 
   lower=$(( "$lower" + 1 ))
 done
 
 # Create a non-DICOM file to allow testing for correct mtime setting
-cat <<EOF | sudo tee "$target_dir"/info.xml > /dev/null
+cat <<EOF | tee "$target_dir"/info.xml > /dev/null
 <xml><info>This is not a DICOM file</info></xml>
 EOF

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -38,9 +38,9 @@ def data_webserver(dataaccess_credential):
             raise ValueError(
                 'Cannot execute tests locally, because the environment '
                 f'variable ``{local_eny_key}´´ is not defined. Set the '
-                f'environment variable ``{local_eny_key}´´ in a startup '
-                f'script, e.g. ~/.bashrc, to point to a local directory that '
-                f'contains study data, as defined in RFD0034.')
+                f'environment variable ``{local_eny_key}´´ to point to '
+                f'a local directory that contains study data, as defined '
+                f'in RFD0034.')
         server = HTTPPath(
             study_dir,
             auth=(dataaccess_credential['user'],


### PR DESCRIPTION
This PR fixes an issue with the download of demo DICOMs, i.e. curl did not follow redirections before this PR.

In addition, there is some code cleanup and message improvements in `tests/fixtures.py`, and a runtime-based check that compares the installed python, git, and git annex versions with the versions used by ICF