### PR TITLE
ci: do not run appveyor if only documentation was changed

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -35,6 +35,11 @@ environment:
   STUDIES_DIR: /data/archive
   STUDIES: "study_1 study_2"
 
+skip_commits:
+  files:
+    - docs/
+    - README.md
+    - .readthedocs.yaml
 
 # In `install` we prep the test system with any non-DataLad tooling
 install:


### PR DESCRIPTION
This adds a commit cherry-picked from #8 (I am not sure whether appveyor behaviour is determined by main or feature branch).