### PR TITLE
BF: add rule for subdatasets to merge when adding catalog entries

### DIFF
--- a/assets/catalog_config.json
+++ b/assets/catalog_config.json
@@ -36,6 +36,10 @@
                 "rule": "merge",
                 "source": "any"
             },
+            "subdatasets": {
+                "rule": "merge",
+                "source": "any"
+            },
             "additional_display": {
                 "rule": "merge",
                 "source": "any"


### PR DESCRIPTION
Without this rule in the catalog config, the catalog's subdatasets tab only shows the first subdataset that was added.