### PR TITLE
Fix build directory in RtD config

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -13,7 +13,7 @@ build:
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
-   configuration: docs/conf.py
+   configuration: docs/source/conf.py
 
 # Optionally declare the Python requirements required to build your docs
 python:


### PR DESCRIPTION
Silly mistake - didn't account for source/build being split.