### PR TITLE
Add inm-icf hostname to CI-VM

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -12,6 +12,8 @@
 # This version of Ubuntu is based on debian bullseye
 image: Ubuntu2004
 
+hosts:
+  data.inm-icf.de: 127.0.0.2
 
 environment:
   # Set this to `post-install` to activate the ssh login after the
@@ -79,13 +81,16 @@ install:
         test.user secret_1
         $STUDIES
 
-  # Run the non-DataLad DICOM data ingestion script
+  # Run the non-DataLad DICOM data ingestion script. Create two visits, i.e.
+  # ``visit_a´´ and ``visit_b´´, for each study defined in ${STUDIES}
   - sh:
       for s in $STUDIES; do
-        sudo bin/make_studyvisit_archive
-          --output-dir "$STUDIES_DIR"
-          --id $s visit_1
-          "$FROM_SCANNER";
+        for v in visit_a visit_b; do
+          sudo bin/make_studyvisit_archive
+            --output-dir "$STUDIES_DIR"
+            --id $s $v
+            "$FROM_SCANNER";
+        done
       done
 
   # Enable external SSH access to CI worker on all other systems. This uses the

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,7 +20,10 @@ from datalad_next.tests.fixtures import (
     existing_noannex_dataset,
 )
 
+# local fixtures setup
 from .fixtures import (
-    data_webserver,
     dataaccess_credential,
+    data_webserver,
+    test_studies_dir,
+    test_study_names,
 )

--- a/tests/test_datalad_workflows/test_example.py
+++ b/tests/test_datalad_workflows/test_example.py
@@ -3,9 +3,7 @@ from pathlib import Path
 
 import pytest
 
-from datalad.api import (
-    download,
-)
+from datalad.api import download
 from datalad_next.exceptions import IncompleteResultsError
 from datalad_next.tests.utils import assert_status
 
@@ -13,7 +11,7 @@ from datalad_next.tests.utils import assert_status
 def test_example_unauthorized(data_webserver):
     with pytest.raises(IncompleteResultsError):
         download(
-            f'{data_webserver}/study_1/visit_1_dicom.tar',
+            f'{data_webserver}/study_1/visit_a_dicom.tar',
             result_renderer='disabled')
 
 
@@ -23,10 +21,10 @@ def test_example_authorized(
 ):
     credman.set(**dataaccess_credential)
 
-    target_file = tmp_path / 'visit_1_dicom.tar'
+    target_file = tmp_path / 'visit_a_dicom.tar'
 
     results = download(
-        {f'{data_webserver}/study_1/visit_1_dicom.tar': target_file},
+        {f'{data_webserver}/study_1/visit_a_dicom.tar': target_file},
         credential=dataaccess_credential['name'],
         result_renderer='disabled',
         on_failure='ignore',


### PR DESCRIPTION
This PR add the inm-icf data server name as hostname of the CI-VM. A hostname is a prerequisite to transition to HTTPS (issue #17).

In addition the PR creates two visits for each study in the CI in order to exercise the dataladification- and catalogification-tests better and fixes an error in the test-fixture `test_studies_dir()`.