### PR TITLE
Switch over to the `archivist` remote

### DIFF
--- a/bin/dataladify_studyvisit_from_meta
+++ b/bin/dataladify_studyvisit_from_meta
@@ -107,25 +107,21 @@ def runshit(wdir, metapath_dataset, metapath_file, repobasepath):
     # assure tar key availability
     repo.call_annex(['setpresentkey', tarkey, uncurl_uuid, '1'])
 
-    # here we register the datalad-archives special remote, to claim
+    # here we register the archivist special remote, to claim
     # the dl+archives URLs registered below.
-    # this really should be the archivist remote, but it is not yet implemented.
-    # this will box ourselves into a corner, and force us to replace the
-    # implementation of datalad-archives with the archivist code, rather than
-    # have them coexist -- otherwise we would need to fix all datasets
     repo.call_annex([
         'initremote',
-        'datalad-archives',
+        'archivist',
         'type=external',
-        'externaltype=datalad-archives',
+        'externaltype=archivist',
         'encryption=none',
         # auto-enabling is cheap (makes no connection attempts), and convenient
         'autoenable=true',
     ])
-    dlarchives_uuid = repo.call_annex_records(
-        ['info', 'datalad-archives'])[0]['uuid']
-    assert dlarchives_uuid
-    
+    archivist_uuid = repo.call_annex_records(
+        ['info', 'archivist'])[0]['uuid']
+    assert archivist_uuid
+
     # load dicom metadata
     dicoms = read_json_file(metapath_file)
     # add to dataset
@@ -147,7 +143,7 @@ def runshit(wdir, metapath_dataset, metapath_file, repobasepath):
         for r in dicom_recs if r.get('action') == 'fromkey'
     ]
     for dicomkey in dicomkeys:
-        repo.call_annex(['setpresentkey', dicomkey, dlarchives_uuid, '1'])
+        repo.call_annex(['setpresentkey', dicomkey, archivist_uuid, '1'])
 
     repo.call_git([
         'remote', 'add', 'icfstore',
@@ -173,6 +169,7 @@ def runshit(wdir, metapath_dataset, metapath_file, repobasepath):
         data='nothing',
     )
 
+
 def read_json_file(file_path):
     """
     Load content from catalog metadata file for current node
@@ -184,7 +181,7 @@ def read_json_file(file_path):
         raise("OS error: {0}".format(err))
     except:
         raise("Unexpected error:", sys.exc_info()[0])
-        
+
 
 if __name__ == '__main__':
     import argparse

--- a/bin/getmeta_studyvisit
+++ b/bin/getmeta_studyvisit
@@ -5,7 +5,6 @@
 import logging
 import os
 from pathlib import Path
-import tempfile
 
 import json
 # this implementation works with pydicom 2x
@@ -58,7 +57,7 @@ def main(store_dir: str,
     tar_path = store_base_dir / study_id / f'{visit_id}_dicom.tar'
     if not tar_path.exists():
         raise ValueError(f'no tarball at {tar_path}')
-    
+
     runshit(
         # source visit tarball
         tar_path.resolve(),
@@ -68,7 +67,7 @@ def main(store_dir: str,
         dataset_metadata_path.absolute(),
         # path to deposit file metadata
         file_metadata_path.absolute(),
-    )        
+    )
 
 
 def runshit(tarpath, tarurl, metapath_dataset, metapath_file):
@@ -112,8 +111,6 @@ def runshit(tarpath, tarurl, metapath_dataset, metapath_file):
             lgr.info('skipping non-DICOM file: %s', r['item'])
     with open(metapath_file, "w") as f:
         json.dump(dicoms, f)
-
-    
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This is coming with datalad/datalad-next#380

I manually tested data access (with external redirection of archive
download to a local cache). Something like this:

```sh
git \
   -c 'remote.uncurl.uncurl-url=file:///tmp/icfstore/{storepath}' \
   -c 'remote.uncurl.uncurl-match=https://data.inm-icf.de/(?P<storepath>.*)$' \
   annex get \
   P000624_P000624/incoming/...2.48.14.966.65880823.dcm
```

works like charm.