### PR TITLE
docs: fix the singularity-calling script

### DIFF
--- a/docs/source/reference/container.rst
+++ b/docs/source/reference/container.rst
@@ -27,7 +27,7 @@ and save it as ``icf-utils``:
 
    #!/bin/sh
    set -e -u
-   singularity run -B <absolute-path-to-data> <absolute-path-to-icf.sif-file> "$@" > icf-utils
+   singularity run -B <absolute-path-to-data> <absolute-path-to-icf.sif-file> "$@"
 
 The ``-B`` defines a bind path, making it accessible from within the
 container.


### PR DESCRIPTION
The instructions for creating the shell script to simplify calling singularity say "save it as icf-utils", but it seems that the provided code block is a mixture of the file content (starts with a hashbang) and a copy-paste snippet to create the file (ends with a redirection to icf-utils).

This removes the seemingly incorrect redirection from the icf-utils shell script definition.