### PR TITLE
Copy files (instead of git clone) on container build

### DIFF
--- a/singularity/icf.def
+++ b/singularity/icf.def
@@ -8,6 +8,12 @@ From: debian:bookworm-slim
 %help
     INM ICF utilities.
 
+%files
+    ./bin /inm-icf-utils/bin
+    ./assets /inm-icf-utils/assets
+    ./requirements-devel.txt /inm-icf-utils/requirements-devel.txt
+    README.md /inm-icf-utils/README.md
+    LICENSE /inm-icf-utils/LICENSE
 
 %post
     # install all non-datalad deps from Debian proper
@@ -20,9 +26,7 @@ From: debian:bookworm-slim
     # datalad-installer cannot install outside /tmp, which will not make it
     # into the final image, move
     mv $(cut -d = -f 2 < /tmp/dlinstaller_env.sh | cut -d : -f 1) /git-annex
-    # the inm-icf-utilities
-    git clone https://github.com/psychoinformatics-de/inm-icf-utilities.git /inm-icf-utils
-    # and the inm-icf-utilities dependencies
+    # the inm-icf-utilities dependencies
     python3 -m pip install --break-system-packages -r /inm-icf-utils/requirements-devel.txt
     # enable "next" extension for patching datalad core, done inside the image, not
     # for a particular user


### PR DESCRIPTION
This recipe would generate the container image from local files, without having to go through github first.

The downside is that now the build process is sensitive to the working directory when running singularity build - it needs to be the repositository base dir.

This potentially removes the informal role of the GitHub main branch as the "rolling release" of sources for the image. Instead, building files locally becomes easier.

This should close #54 

TODO:
- [x] verify that full workflow works (I only tested whether `--help` can be called)
- [x] verify that everything still builds and tests correctly in the CI environment