### PR TITLE
fix: strip complete base directory from tarfile paths

### DIFF
--- a/bin/make_studyvisit_archive
+++ b/bin/make_studyvisit_archive
@@ -85,6 +85,7 @@ def write_archive(
             # adjust properties to make archive builds reproducible
             tinfo = normalize_tarinfo(
                 tinfo,
+                input_base_dir,
                 archive_content_base_dir,
                 # go with the reported timestamp from DICOM or with default
                 content[p] or default_timestamp,
@@ -94,9 +95,10 @@ def write_archive(
                 tar.addfile(tinfo, fp)
 
 
-def normalize_tarinfo(tinfo, archive_path, timestamp):
+def normalize_tarinfo(tinfo, input_base_dir, archive_path, timestamp):
     # strip first level and replace with generated archive root dir name
-    tinfo.name = str(Path(archive_path, *Path(tinfo.name).parts[1:]))
+    input_path = (Path('/') / tinfo.name).relative_to(input_base_dir)
+    tinfo.name = str(Path(archive_path) / input_path)
     # be safe
     tinfo.uid = 0
     tinfo.gid = 0

--- a/tests/modules/make_studyvisit_archive.py
+++ b/tests/modules/make_studyvisit_archive.py
@@ -1,0 +1,1 @@
+../../bin/make_studyvisit_archive

--- a/tests/test_path_handling.py
+++ b/tests/test_path_handling.py
@@ -1,0 +1,24 @@
+
+import sys
+import tarfile
+from pathlib import Path
+
+from .modules.make_studyvisit_archive import main
+
+
+def test_path_handling(tmp_path):
+    base_dir = tmp_path / 'input' / 'd_1' / 'd_1_1' / 'd_1_1_1'
+    base_dir.mkdir(parents=True)
+    (base_dir / 'file1.txt').write_text('content 1')
+    (base_dir / 'file2.txt').write_text('content 2')
+
+    output_base_dir = tmp_path / 'output'
+
+    study_id, visit_id = 'study_1', 'visit_1'
+    main(str(base_dir), str(output_base_dir), study_id, visit_id)
+
+    tar_file = tarfile.open(output_base_dir / study_id / f'{visit_id}_dicom.tar')
+    assert tar_file.getnames() == [
+        f'{study_id}_{visit_id}/file1.txt',
+        f'{study_id}_{visit_id}/file2.txt',
+    ]


### PR DESCRIPTION
Fixes #53
Strip the complete input base directory from the paths that are used in the study-visit tar-files.
