### PR TITLE
Change generation of inner tar paths: set the base directory but avoid including too many components

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,31 @@
+# This CITATION.cff file was generated with cffinit.
+# Visit https://bit.ly/cffinit to generate yours today!
+
+cff-version: 1.2.0
+title: inm-icf-utilities
+message: >-
+  If you use this software, please cite it using the
+  metadata from this file.
+type: software
+authors:
+  - given-names: Christian
+    family-names: Mönch
+  - given-names: Michael
+    family-names: Hanke
+  - given-names: Michał
+    family-names: Szczepanik
+  - given-names: 'Adina S. '
+    family-names: Wagner
+  - given-names: Stephan
+    family-names: Heunis
+  - given-names: Yaroslav O.
+    family-names: Halchenko
+repository-code: 'https://github.com/psychoinformatics-de/inm-icf-utilities'
+url: 'https://inm-icf-utilities.readthedocs.io'
+abstract: >+
+  The ICF archive provides storage of MRI data acquisitions
+  in DICOM format for the purpose of long-term data
+  preservation, with the ability to grant read-access to a
+  data subset to authorized individuals.
+
+license: MIT

--- a/bin/make_studyvisit_archive
+++ b/bin/make_studyvisit_archive
@@ -81,7 +81,12 @@ def write_archive(
     with tarfile.open(dest_path, "w") as tar:
         # order of member in archive is significant, sort by path
         for p in tqdm(sorted(content), 'Composing archive', unit=' files'):
-            tinfo = tar.gettarinfo(name=p)
+            p_rel = p.relative_to(input_base_dir)
+            tinfo = tar.gettarinfo(
+                name=p,
+                # use normalized base dir + path relative to input dir
+                arcname=Path(archive_content_base_dir, *p_rel.parts)
+            )
             # adjust properties to make archive builds reproducible
             tinfo = normalize_tarinfo(
                 tinfo,
@@ -95,8 +100,6 @@ def write_archive(
 
 
 def normalize_tarinfo(tinfo, archive_path, timestamp):
-    # strip first level and replace with generated archive root dir name
-    tinfo.name = str(Path(archive_path, *Path(tinfo.name).parts[1:]))
     # be safe
     tinfo.uid = 0
     tinfo.gid = 0

--- a/tests/modules/make_studyvisit_archive.py
+++ b/tests/modules/make_studyvisit_archive.py
@@ -1,0 +1,1 @@
+../../bin/make_studyvisit_archive

--- a/tests/test_path_handling.py
+++ b/tests/test_path_handling.py
@@ -1,0 +1,24 @@
+
+import sys
+import tarfile
+from pathlib import Path
+
+from .modules.make_studyvisit_archive import main
+
+
+def test_path_handling(tmp_path):
+    base_dir = tmp_path / 'input' / 'd_1' / 'd_1_1' / 'd_1_1_1'
+    base_dir.mkdir(parents=True)
+    (base_dir / 'file1.txt').write_text('content 1')
+    (base_dir / 'file2.txt').write_text('content 2')
+
+    output_base_dir = tmp_path / 'output'
+
+    study_id, visit_id = 'study_1', 'visit_1'
+    main(str(base_dir), str(output_base_dir), study_id, visit_id)
+
+    tar_file = tarfile.open(output_base_dir / study_id / f'{visit_id}_dicom.tar')
+    assert tar_file.getnames() == [
+        f'{study_id}_{visit_id}/file1.txt',
+        f'{study_id}_{visit_id}/file2.txt',
+    ]


### PR DESCRIPTION
This uses `Path.relative_to()` and the `arcname` parameter of `tar.gettarinfo()` to specify names for files in the archive. We keep setting the base directory. The behaviour is similar to "tar -C" but with that directory added. Fixes #53 

This changes the previous approach, which only replaced one leading path component. That caused potentially unwanted leading path components to be included in the tar paths whenever the input directory given to the script was a path with more than two components. It was mostly noticeable when using absolute paths. E.g. for `/tmp/dicomdir` our code would replace `/tmp` and keep `dicomdir`; for `~/Documents/foo/dicomdir` it would would replace `/home` and keep `username/Documents/foo/dicomdir`.

This should make the behaviour consistent with the following docstring (although "base directory" can be slightly ambiguous):

>  The input base directory itself is not put into the archive (i.e., its own name is irrelevant). Instead, a top-level directory with the  name '<study-id>_<visit_id>' is used to place all archive content in.