### PR TITLE
Unify -o long option to be --store-dir

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -80,7 +80,7 @@ install:
       for s in $STUDIES; do
         for v in visit_a visit_b; do
           icf-utils make_studyvisit_archive
-            --output-dir "$STUDIES_DIR"
+            --store-dir "$STUDIES_DIR"
             --id $s $v
             "$FROM_SCANNER";
         done

--- a/bin/make_studyvisit_archive
+++ b/bin/make_studyvisit_archive
@@ -208,7 +208,7 @@ if __name__ == '__main__':
         store_dir = args.output_dir
         msg = (
             "--output-dir argument is deprecated and will be removed "
-            "in the future. Use use -o/--store-dir instead."
+            "in the future. Use -o/--store-dir instead."
         )
         warnings.warn(msg, DeprecationWarning)
     else:

--- a/bin/make_studyvisit_archive
+++ b/bin/make_studyvisit_archive
@@ -22,6 +22,7 @@ from datetime import datetime
 from hashlib import md5
 from pathlib import Path
 from typing import Dict
+import warnings
 
 from tqdm import tqdm
 
@@ -178,11 +179,16 @@ def main(input_base_dir: str,
 if __name__ == '__main__':
     import argparse
     p = argparse.ArgumentParser(description=__doc__)
-    p.add_argument(
-        "-o", "--output-dir", metavar='PATH', default=os.getcwd(),
+    g = p.add_mutually_exclusive_group()
+    g.add_argument(
+        "-o", "--store-dir", metavar='PATH', default=os.getcwd(),
         help="Base directory to place the archive structure in. "
         "The corresponding '<study-id>/' subdirectory for the "
-        "study is created automatically, if needed")
+        "study is created automatically, if needed.")
+    g.add_argument(
+        "--output-dir", metavar="PATH",
+        help="Deprecated, will be removed in the future; "
+        "use -o/--store-dir instead.")
     p.add_argument(
         '--id', nargs=2, metavar=('STUDY-ID', 'VISIT-ID'), required=True,
         help="The study and visit identifiers, used to name and "
@@ -198,8 +204,18 @@ if __name__ == '__main__':
         "directory with the name '<study-id>_<visit_id>' is used "
         "to place all archive content in.")
     args = p.parse_args()
+    if args.output_dir is not None:
+        store_dir = args.output_dir
+        msg = (
+            "--output-dir argument is deprecated and will be removed "
+            "in the future. Use use -o/--store-dir instead."
+        )
+        warnings.warn(msg, DeprecationWarning)
+    else:
+        store_dir = args.store_dir
+
     main(input_base_dir=args.input_dir,
-         output_base_dir=args.output_dir,
+         output_base_dir=store_dir,
          study_id=args.id[0],
          visit_id=args.id[1],
     )


### PR DESCRIPTION
This changes `make_studyvisit_archive` to use `-o / --store-dir`, consistent with the other three scripts. The `--output-dir` argument is marked as deprecated but remains supported for the time being. Closes #52 

Use of both long forms is guarded againist by using a mutually exclusive group. A deprecation warning is issued when --output-dir is used. When the deprecated parameter is removed, both the group and the warning can be done away with.

As a side note, it seems that Python 3.13 will add "deprecated" to argparse's add_argument:
https://docs.python.org/3.13/library/argparse.html#deprecated